### PR TITLE
Fixed spelling error in the commandPalette dictionary

### DIFF
--- a/autoload/ctrlp/commandpalette_commands.vim
+++ b/autoload/ctrlp/commandpalette_commands.vim
@@ -112,7 +112,7 @@ let s:commandPalette = {
     \   'vsplit',
     \ 'Paste mode: Toggle':
     \   'set paste!',
-    \ 'Text witdh: Set':
+    \ 'Text width: Set':
     \   'call ctrlp#commandpalette_commands#TextWidth()',
     \ 'Syntax highlighting: Set':
     \   'call ctrlp#commandpalette_commands#SetSyntax()',


### PR DESCRIPTION
changed 'Text witdh' to Text width'. very minor, but it was bugging me.
